### PR TITLE
Fix issue #39.

### DIFF
--- a/src/bin/cargo-rerast.rs
+++ b/src/bin/cargo-rerast.rs
@@ -318,8 +318,8 @@ fn cargo_rerast() -> Result<(), Error> {
     }
     if let Some(crate_root) = matches.value_of("crate_root") {
         std::env::set_current_dir(crate_root)?;
-    } else if let JsonValue::String(s) = &metadata()?["workspace_root"] {
-        std::env::set_current_dir(s)?
+    } else if let Some(s) = &metadata()?["workspace_root"].as_str() {
+        std::env::set_current_dir(s)?;
     }
     let mut maybe_compiler_invocation_infos = None;
     let rules = if let Some(replacement) = matches.value_of("replace_with") {


### PR DESCRIPTION
When looking for the workspace root, the match:

```rust
 if let JsonValue::String(s) = &metadata()?["workspace_root"]
```

was not succeding as the value was actually `JsonValue::Short(...)`,
an alternative string representation.

Switch to calling `JsonValue`'s `as_str()` method and matching on
the result, which should work in both cases.